### PR TITLE
show lapmode, including a preference, which defaults to off

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -12,6 +12,7 @@ const Config = imports.misc.config;
 
 const BAT_STATUS = "/sys/class/power_supply/BAT0/status";
 const POWER_NOW = "/sys/class/power_supply/BAT0/power_now";
+const LAPMODE = "/sys/devices/platform/thinkpad_acpi/dytc_lapmode"
 
 
 /** Indicator
@@ -44,8 +45,24 @@ var TPIndicator = GObject.registerClass(
             } else if (status == 'Discharging') {
                 sign = '-';
             }
+            let lap_mode_char = this._getLapMode()
+            return _("%s%% %s%sW%s").format(pct, sign, power, lap_mode_char);
+        }
 
-            return _("%s%% %s%sW").format(pct, sign, power);
+        _getLapMode() {
+            const show_lap_mode = this.settings.get_boolean('lap-mode');
+            if (!show_lap_mode){
+                return ('')
+            }
+            const status = this._read_file(LAPMODE, '???');
+            let lap_mode_char = '';
+            if (status == '1') {
+                lap_mode_char = " lap";
+            }
+            else {
+                lap_mode_char = ''
+            }
+            return (lap_mode_char)
         }
 
         _sync() {

--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,7 @@
     "name": "tp_wattmeter",
     "uuid": "tp_wattmeter@gistart",
     "url": "https://github.com/gistart/tp_wattmeter",
+    "version": 20220918,
     "description": "Shows battery power consumption of ThinkPad laptops. Now configurable!",
     "shell-version": [
         "40",

--- a/prefs.js
+++ b/prefs.js
@@ -35,6 +35,14 @@ function fillPreferencesWindow(window) {
     period_row.add_suffix(period_spin);
     period_row.activatable_widget = period_spin;
 
+    // show lap mode for ThinkPads from T490 era (gen 8 intel cpu) onwwards
+
+    const lap_mode_row = new Adw.ActionRow({ title: LBL_LAP_MODE });
+    group.add(lap_mode_row);
+    const lap_mode_switch = makeLapModeSwitch(settings);
+    lap_mode_row.add_suffix(lap_mode_switch);
+    lap_mode_row.activatable_widget = lap_mode_switch;
+
     // done
     window.add(page);
 }
@@ -82,6 +90,7 @@ function buildPrefsWidget() {
 const SETTINGS_ID = 'org.gnome.shell.extensions.tp_wattmeter';
 const LBL_AVG = 'Show average of this many measurements';
 const LBL_PERIOD = 'Period between measurements in seconds';
+const LBL_LAP_MODE = 'Show status of lap mode thermal throttling';
 
 
 function makeAvgOfSpin(settings) {
@@ -102,6 +111,22 @@ function makeAvgOfSpin(settings) {
         Gio.SettingsBindFlags.DEFAULT
     );
     return avg_spin;
+}
+
+function makeLapModeSwitch(settings) {
+    const lap_mode_switch = new Gtk.Switch({
+            active: settings.get_boolean('lap-mode'),
+            halign: Gtk.Align.END,
+            valign: Gtk.Align.CENTER,
+        });
+
+    settings.bind(
+        'lap-mode',
+        lap_mode_switch,
+        'active',
+        Gio.SettingsBindFlags.DEFAULT
+    );
+    return lap_mode_switch;
 }
 
 

--- a/schemas/org.gnome.shell.extensions.tp_wattmeter.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.tp_wattmeter.gschema.xml
@@ -6,6 +6,9 @@
         </key>
         <key name="period-sec" type="d">
             <default>1.0</default>
-        </key>    
+        </key>
+        <key name="lap-mode" type="b">
+            <default>false</default>
+        </key>
     </schema>
 </schemalist>


### PR DESCRIPTION
For ThinkPads which support it, show " lap" after the power consumption to indicate that the laptop is in lap mode, which throttles. When lap mode is disabled (typically after aroud four minutes of no motion) the ' lap' string is removed.

Showing this is controlled by a preference, which deletes to false. There is no effort to detect if the laptop actually supports this.

lap mode will throttle the laptop to around 65C. It is triggered with a fairly small amount of movement, even moving the laptop on the desk may trigger it. 